### PR TITLE
Use protocol relative URL for css

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
   <link rel="shortcut icon" href="/favicon.png">
   <link rel="alternate" type="application/atom+xml" title="{{ site.data.theme.name }}" href="{{site.url}}/atom.xml" />
 
-  <link rel="stylesheet" href="{{ site.github.url }}/assets/css/all.css">
+  <link rel="stylesheet" href="{{ site.github.url | replace:'http://','//' }}/assets/css/all.css">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha256-k2/8zcNbxVIh5mnQ52A0r3a6jAgMGxFJFE2707UxGCk= sha512-ZV9KawG2Legkwp3nAlxLIVFudTauWuBpC10uEafMHYL0Sarrz5A7G79kXh5+5+woxQ5HM559XX2UZjMJ36Wplg==" crossorigin="anonymous">
 </head>
 <body>


### PR DESCRIPTION
The CSS on the secure version of https://ourdataourhands.org/ did not load for me because it was loading from an insecure URL.

Replace `http://` in the `site.github.url` so css is protocol relative and we can see pretty + secure site 😄 .